### PR TITLE
UPDATE: Migrate image downloads to modern-screenshot

### DIFF
--- a/components/balatro.tsx
+++ b/components/balatro.tsx
@@ -142,7 +142,20 @@ export default function Balatro({
   useEffect(() => {
     if (!containerRef.current) return;
     const container = containerRef.current;
-    const renderer = new Renderer();
+
+    const canvas = document.createElement("canvas");
+    const glContext =
+      canvas.getContext("webgl2", {
+        alpha: true,
+        preserveDrawingBuffer: true,
+      }) ||
+      canvas.getContext("webgl", {
+        alpha: true,
+        preserveDrawingBuffer: true,
+      });
+    if (!glContext) return;
+
+    const renderer = new Renderer({ canvas, webgl: 2, alpha: true });
     const gl = renderer.gl;
     gl.clearColor(0, 0, 0, 1);
 

--- a/components/download-card-button.tsx
+++ b/components/download-card-button.tsx
@@ -2,7 +2,7 @@
 
 import { Download01Icon, Loading03Icon } from "@hugeicons/core-free-icons";
 import { HugeiconsIcon } from "@hugeicons/react";
-import { toPng } from "html-to-image";
+import { domToPng } from "modern-screenshot";
 import * as React from "react";
 
 import { Button } from "@/components/ui/button";
@@ -12,6 +12,61 @@ type DownloadCardButtonProps = {
   fileName?: string;
   pixelRatio?: number;
 };
+
+function captureWebGLToImage(canvas: HTMLCanvasElement): string | null {
+  const gl = canvas.getContext("webgl2") || canvas.getContext("webgl");
+  if (!gl) {
+    try {
+      return canvas.toDataURL("image/png");
+    } catch {
+      return null;
+    }
+  }
+
+  const width = canvas.width;
+  const height = canvas.height;
+
+  const pixels = new Uint8Array(width * height * 4);
+  gl.readPixels(0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, pixels);
+
+  const tempCanvas = document.createElement("canvas");
+  tempCanvas.width = width;
+  tempCanvas.height = height;
+  const ctx = tempCanvas.getContext("2d");
+  if (!ctx) return null;
+
+  const imageData = ctx.createImageData(width, height);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      const srcIdx = (y * width + x) * 4;
+      const dstIdx = ((height - y - 1) * width + x) * 4;
+      imageData.data[dstIdx] = pixels[srcIdx];
+      imageData.data[dstIdx + 1] = pixels[srcIdx + 1];
+      imageData.data[dstIdx + 2] = pixels[srcIdx + 2];
+      imageData.data[dstIdx + 3] = pixels[srcIdx + 3];
+    }
+  }
+
+  ctx.putImageData(imageData, 0, 0);
+  return tempCanvas.toDataURL("image/png");
+}
+
+function captureWebGLCanvases(
+  container: HTMLElement
+): Map<HTMLCanvasElement, string> {
+  const captures = new Map<HTMLCanvasElement, string>();
+  const canvases = container.querySelectorAll("canvas");
+
+  for (const canvas of canvases) {
+    const dataUrl = captureWebGLToImage(canvas);
+    if (dataUrl) {
+      captures.set(canvas, dataUrl);
+    }
+  }
+
+  return captures;
+}
 
 export default function DownloadCardButton({
   targetId,
@@ -26,52 +81,53 @@ export default function DownloadCardButton({
 
     setIsDownloading(true);
     try {
-      // Ensure webfonts have a chance to load before snapshotting.
-      // (Avoids font fallback changing text metrics in the export.)
       try {
         await document.fonts?.ready;
       } catch {
         // ignore
       }
 
-      const options = {
-        cacheBust: true,
-        pixelRatio,
-        // Avoid html-to-image font embedding (can change fonts + can crash on some stylesheets).
-        // We rely on the already-loaded page fonts instead.
-        skipFonts: true,
-        fontEmbedCSS: "",
-        onClone: (doc: Document) => {
-          const cloned = doc.getElementById(targetId) as HTMLElement | null;
-          if (!cloned) return;
+      const webglCaptures = captureWebGLCanvases(node);
 
-          // Flatten 3D transforms for export; html-to-image can mis-handle
-          // perspective/translateZ and inflate text metrics.
-          cloned.style.transform = "none";
-          cloned.style.transformStyle = "flat";
-          cloned.style.boxShadow = "none";
+      const dataUrl = await domToPng(node, {
+        scale: pixelRatio,
+        features: {
+          removeControlCharacter: false,
+        },
+        onCloneNode: (clonedNode) => {
+          if (!(clonedNode instanceof HTMLElement)) return;
 
-          const transformed = cloned.querySelectorAll<HTMLElement>(
-            '[style*="translateZ"], [style*="perspective"], [style*="rotateX"], [style*="rotateY"]'
-          );
-          transformed.forEach((el) => {
-            el.style.transform = "none";
-            el.style.transformStyle = "flat";
+          const clonedCanvases = clonedNode.querySelectorAll("canvas");
+          const originalCanvases = node.querySelectorAll("canvas");
+
+          clonedCanvases.forEach((clonedCanvas, index) => {
+            const originalCanvas = originalCanvases[index];
+            const capture = webglCaptures.get(originalCanvas);
+
+            if (capture) {
+              const img = document.createElement("img");
+              img.src = capture;
+              img.style.cssText = clonedCanvas.style.cssText;
+              img.style.width =
+                clonedCanvas.style.width || `${originalCanvas.offsetWidth}px`;
+              img.style.height =
+                clonedCanvas.style.height || `${originalCanvas.offsetHeight}px`;
+              img.style.position = "absolute";
+              img.style.top = "0";
+              img.style.left = "0";
+
+              clonedCanvas.parentNode?.replaceChild(img, clonedCanvas);
+            }
           });
 
-          // Prevent unexpected wrapping in the export without forcing a specific font.
-          const clonedTitle = cloned.querySelector<HTMLElement>(
-            '[data-export="title"]'
-          );
-          if (clonedTitle) clonedTitle.style.whiteSpace = "nowrap";
+          if (clonedNode.id === targetId) {
+            clonedNode.style.transform = "none";
+            clonedNode.style.transformStyle = "flat";
+          }
         },
-      };
+      });
 
-      const dataUrl = await toPng(
-        node,
-        options as unknown as Parameters<typeof toPng>[1]
-      );
-
+      // Download the image
       const link = document.createElement("a");
       link.href = dataUrl;
       link.download = fileName;

--- a/components/light-pillar.tsx
+++ b/components/light-pillar.tsx
@@ -63,6 +63,7 @@ const LightPillar: React.FC<LightPillarProps> = ({
       renderer = new THREE.WebGLRenderer({
         antialias: false,
         alpha: true,
+        preserveDrawingBuffer: true,
         powerPreference: "high-performance",
         precision: "lowp",
         stencil: false,

--- a/components/liquid-chrome.tsx
+++ b/components/liquid-chrome.tsx
@@ -29,7 +29,27 @@ export const LiquidChrome: React.FC<LiquidChromeProps> = ({
     if (!containerRef.current) return;
 
     const container = containerRef.current;
-    const renderer = new Renderer({ antialias: true, alpha: true });
+
+    const canvas = document.createElement("canvas");
+    const glContext =
+      canvas.getContext("webgl2", {
+        alpha: true,
+        antialias: true,
+        preserveDrawingBuffer: true,
+      }) ||
+      canvas.getContext("webgl", {
+        alpha: true,
+        antialias: true,
+        preserveDrawingBuffer: true,
+      });
+    if (!glContext) return;
+
+    const renderer = new Renderer({
+      canvas,
+      antialias: true,
+      alpha: true,
+      webgl: 2,
+    });
     const gl = renderer.gl;
     gl.clearColor(0, 0, 0, 0);
     const opacityClamped = Math.max(0, Math.min(1, opacity));

--- a/components/liquid-ether.tsx
+++ b/components/liquid-ether.tsx
@@ -141,8 +141,8 @@ export default function LiquidEther({
         this.renderer = new THREE.WebGLRenderer({
           antialias: true,
           alpha: true,
+          preserveDrawingBuffer: true,
         });
-        // Always transparent
         this.renderer.autoClear = false;
         this.renderer.setClearColor(new THREE.Color(0x000000), 0);
         this.renderer.setPixelRatio(this.pixelRatio);
@@ -1072,6 +1072,8 @@ export default function LiquidEther({
       render() {
         if (!Common.renderer) return;
         Common.renderer.setRenderTarget(null);
+        // Clear the canvas with transparent black before rendering
+        Common.renderer.clear();
         Common.renderer.render(this.scene, this.camera);
       }
       update() {

--- a/components/plasma.tsx
+++ b/components/plasma.tsx
@@ -114,14 +114,28 @@ export const Plasma: React.FC<PlasmaProps> = ({
 
     const directionMultiplier = direction === "reverse" ? -1.0 : 1.0;
 
+    const canvas = document.createElement("canvas");
+    const glContext =
+      canvas.getContext("webgl2", {
+        alpha: true,
+        antialias: false,
+        preserveDrawingBuffer: true,
+      }) ||
+      canvas.getContext("webgl", {
+        alpha: true,
+        antialias: false,
+        preserveDrawingBuffer: true,
+      });
+    if (!glContext) return;
+
     const renderer = new Renderer({
+      canvas,
       webgl: 2,
       alpha: true,
       antialias: false,
       dpr: Math.min(window.devicePixelRatio || 1, 2),
     });
     const gl = renderer.gl;
-    const canvas = gl.canvas as HTMLCanvasElement;
     canvas.style.display = "block";
     canvas.style.width = "100%";
     canvas.style.height = "100%";

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clsx": "^2.1.1",
     "dotenv": "^17.2.3",
     "drizzle-orm": "^0.45.1",
-    "html-to-image": "^1.11.13",
+    "modern-screenshot": "^4.6.7",
     "next": "16.1.1",
     "next-themes": "^0.4.6",
     "nuqs": "^2.8.6",


### PR DESCRIPTION
Replaced the html-to-image package with the better modern-screenshot approach.

This allows better image downloads, preserving styling, fonts, and also the cool overlay effects that use WebGL.

Also updated the shaders to support this feature.

Also fixed a bug where liquid-ether would cover the content of the card instead of being a transparent overlay.

Here's an example of a downloaded image after these changes (was using a mock image because I can't access the DB):

<img width="448" height="994" alt="epic-creature (1)" src="https://github.com/user-attachments/assets/1af8df27-e0e8-402a-ae56-874c9d03dae4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebGL canvas capture support for improved export and download functionality.

* **Bug Fixes**
  * Improved WebGL rendering setup and stability across components.
  * Enhanced screenshot and export functionality to properly handle WebGL elements.

* **Chores**
  * Updated screenshot library dependency for better export performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->