### PR TITLE
fix(ui): center creature cards on profile pages

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -63,7 +63,7 @@ async function CreatureCardWrapper({ params }: { params: Params }) {
 
 export default function CreaturePage({ params }: { params: Params }) {
   return (
-    <main className="flex min-h-svh w-full flex-col items-center justify-center px-5 pt-20 pb-8">
+    <main className="flex min-h-svh w-full flex-col items-center justify-center overflow-x-hidden px-5 pt-20 pb-8">
       <Suspense fallback={<Skeleton className="h-96 w-72" />}>
         <CreatureCardWrapper params={params} />
       </Suspense>

--- a/components/creature-card.tsx
+++ b/components/creature-card.tsx
@@ -247,144 +247,151 @@ export default async function CreatureCard({
   const cardDomId = `creature-card-${usernameLower}`;
 
   return (
-    <div className="flex w-full min-w-0 max-w-full flex-col items-center dark">
-      <div className="relative flex w-full min-w-0 max-w-96 flex-col items-start gap-4 sm:flex-row">
+    <div
+      className={cn(
+        "relative grid w-full min-w-0 justify-items-center dark",
+        stats &&
+          "lg:grid-cols-[minmax(0,1fr)_minmax(0,24rem)_minmax(0,1fr)] lg:items-start"
+      )}
+    >
+      {stats ? (
         <input
           id={toggleId}
           type="checkbox"
           className="peer absolute top-0 left-0 size-px appearance-none border-0 p-0 opacity-0"
         />
+      ) : null}
 
-        <div
-          className={cn(
-            "relative w-full min-w-0 overflow-x-clip transition-transform duration-500 ease-out motion-reduce:transition-none",
-            "peer-checked:sm:-translate-x-1",
-            "peer-checked:**:data-[state=reveal]:hidden",
-            "peer-checked:**:data-[state=hide]:inline",
-            "peer-checked:**:data-[slot=arrow]:rotate-180"
-          )}
-        >
-          {stats && (
-            <div className="absolute -top-10 right-0 z-10 flex justify-end mr-6">
-              <div className="lg:hidden w-full">
-                <CreatureStatsDialog triggerText="View stats">
-                  <CreatureStats
-                    creature={creature}
-                    downloadTargetId={cardDomId}
-                  />
-                </CreatureStatsDialog>
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                className="hidden lg:inline-flex"
-                nativeButton={false}
-                render={<label htmlFor={toggleId} />}
-              >
-                <span data-state="reveal">Reveal stats</span>
-                <span data-state="hide" className="hidden">
-                  Hide stats
-                </span>
-                <HugeiconsIcon
-                  icon={ArrowRight01Icon}
-                  className="transition-transform duration-300 motion-reduce:transition-none"
-                  data-icon="inline-end"
-                  data-slot="arrow"
-                />
-              </Button>
-            </div>
-          )}
-
-          <ThreeDCard
-            enableShadow={false}
-            hoverPadding={0}
-            innerId={cardDomId}
-            trackOnWindow
-            className="w-full min-w-0"
-          >
-            <Card
-              className={cn(
-                "relative w-full max-w-full rounded-xl p-0",
-                theme.cardClassName
-              )}
-            >
-              <div className="absolute left-3 top-3 z-20">
-                <Link
-                  href={githubProfileUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className={cn(
-                    "group relative inline-flex rounded-full p-px",
-                    emblemTheme.ringClassName,
-                    emblemTheme.glowClassName
-                  )}
-                >
-                  <span
-                    className={cn(
-                      "pointer-events-none absolute -inset-1 rounded-full blur opacity-35 transition-opacity group-hover:opacity-60",
-                      emblemTheme.ringClassName
-                    )}
-                  />
-                  <span className="relative inline-flex items-center gap-2 rounded-full border border-white/10 bg-background/70 px-3 py-1 text-xs font-semibold backdrop-blur supports-backdrop-filter:bg-background/50">
-                    <span
-                      className={cn("font-mono", emblemTheme.textClassName)}
-                    >
-                      @{usernameLower}
-                    </span>
-                  </span>
-                </Link>
-              </div>
-              <div
-                className={cn(
-                  "w-full absolute top-0 left-0 h-full border-3 rounded-[calc(var(--radius)+7px)]",
-                  theme.frameClassName
-                )}
-              >
-                {theme.effects}
-              </div>
-              <CardHeader className="p-0 flex flex-col gap-3">
-                <Image
-                  src={creature.image}
-                  alt={creature.name || "GitHub creature"}
-                  width={350}
-                  height={350}
-                  crossOrigin="anonymous"
-                  className="w-full"
-                />
-                <CardTitle
-                  data-export="title"
-                  className="px-4 text-2xl sm:text-2xl font-bold tracking-normal leading-tight"
-                >
-                  <span className="bg-linear-to-r from-foreground via-foreground/90 to-foreground/70 bg-clip-text text-transparent">
-                    {creature.name}
-                  </span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="px-4 pb-4">
-                <p className="leading-relaxed text-balance text-foreground/80">
-                  {creature.description}
-                </p>
-              </CardContent>
-            </Card>
-          </ThreeDCard>
-        </div>
-
+      <div
+        className={cn(
+          "relative w-full min-w-0 max-w-96",
+          stats &&
+            "lg:col-start-2 peer-checked:**:data-[state=reveal]:hidden peer-checked:**:data-[state=hide]:inline peer-checked:**:data-[slot=arrow]:rotate-180"
+        )}
+      >
         {stats && (
-          <div
-            className={cn(
-              "hidden lg:block overflow-hidden",
-              "transition-[max-width,opacity,transform] duration-500 ease-out will-change-[max-width,opacity,transform]",
-              "max-w-0 opacity-0 translate-x-2 pointer-events-none",
-              "peer-checked:max-w-[24rem] peer-checked:opacity-100 peer-checked:translate-x-0 peer-checked:pointer-events-auto"
-            )}
-          >
-            <div className="p-3">
-              <CreatureStats creature={creature} downloadTargetId={cardDomId} />
+          <div className="absolute -top-10 right-0 z-10 flex justify-end">
+            <div className="w-full lg:hidden">
+              <CreatureStatsDialog triggerText="View stats">
+                <CreatureStats
+                  creature={creature}
+                  downloadTargetId={cardDomId}
+                />
+              </CreatureStatsDialog>
             </div>
+
+            <Button
+              variant="outline"
+              size="sm"
+              className="hidden lg:inline-flex"
+              nativeButton={false}
+              render={<label htmlFor={toggleId} />}
+            >
+              <span data-state="reveal">Reveal stats</span>
+              <span data-state="hide" className="hidden">
+                Hide stats
+              </span>
+              <HugeiconsIcon
+                icon={ArrowRight01Icon}
+                className="transition-transform duration-300 motion-reduce:transition-none"
+                data-icon="inline-end"
+                data-slot="arrow"
+              />
+            </Button>
           </div>
         )}
+
+        <ThreeDCard
+          enableShadow={false}
+          hoverPadding={0}
+          innerId={cardDomId}
+          trackOnWindow
+          className="w-full min-w-0"
+        >
+          <Card
+            className={cn(
+              "relative w-full max-w-full rounded-xl p-0",
+              theme.cardClassName
+            )}
+          >
+            <div className="absolute left-3 top-3 z-20">
+              <Link
+                href={githubProfileUrl}
+                target="_blank"
+                rel="noreferrer"
+                className={cn(
+                  "group relative inline-flex rounded-full p-px",
+                  emblemTheme.ringClassName,
+                  emblemTheme.glowClassName
+                )}
+              >
+                <span
+                  className={cn(
+                    "pointer-events-none absolute -inset-1 rounded-full blur opacity-35 transition-opacity group-hover:opacity-60",
+                    emblemTheme.ringClassName
+                  )}
+                />
+                <span className="relative inline-flex items-center gap-2 rounded-full border border-white/10 bg-background/70 px-3 py-1 text-xs font-semibold backdrop-blur supports-backdrop-filter:bg-background/50">
+                  <span className={cn("font-mono", emblemTheme.textClassName)}>
+                    @{usernameLower}
+                  </span>
+                </span>
+              </Link>
+            </div>
+            <div
+              className={cn(
+                "w-full absolute top-0 left-0 h-full border-3 rounded-[calc(var(--radius)+7px)]",
+                theme.frameClassName
+              )}
+            >
+              {theme.effects}
+            </div>
+            <CardHeader className="p-0 flex flex-col gap-3">
+              <Image
+                src={creature.image}
+                alt={creature.name || "GitHub creature"}
+                width={350}
+                height={350}
+                crossOrigin="anonymous"
+                className="w-full"
+              />
+              <CardTitle
+                data-export="title"
+                className="px-4 text-2xl sm:text-2xl font-bold tracking-normal leading-tight"
+              >
+                <span className="bg-linear-to-r from-foreground via-foreground/90 to-foreground/70 bg-clip-text text-transparent">
+                  {creature.name}
+                </span>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="px-4 pb-4">
+              <p className="leading-relaxed text-balance text-foreground/80">
+                {creature.description}
+              </p>
+            </CardContent>
+          </Card>
+        </ThreeDCard>
       </div>
+
+      {stats ? (
+        <div
+          className={cn(
+            "hidden min-w-0 lg:col-start-3 lg:block lg:justify-self-stretch",
+            "overflow-hidden transition-[max-height,opacity,transform] duration-500 ease-out will-change-[max-height,opacity,transform] motion-reduce:transition-none",
+            "max-h-0 opacity-0 translate-x-2 pointer-events-none",
+            "peer-checked:max-h-[80rem] peer-checked:opacity-100 peer-checked:translate-x-0 peer-checked:pointer-events-auto"
+          )}
+        >
+          <div className="p-3">
+            <CreatureStats
+              creature={creature}
+              downloadTargetId={cardDomId}
+              hideIdentity
+              className="max-w-full"
+            />
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/components/creature-stats.tsx
+++ b/components/creature-stats.tsx
@@ -15,29 +15,45 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
 import { getCreatureTopPercentage } from "@/server/creatures";
 
 interface CreatureStatsProps {
   creature: SelectCreature;
   downloadTargetId?: string;
+  hideIdentity?: boolean;
+  className?: string;
 }
 
 export default async function CreatureStats({
   creature,
   downloadTargetId,
+  hideIdentity,
+  className,
 }: CreatureStatsProps) {
   const topPercentage = await getCreatureTopPercentage(creature.id);
 
   return (
-    <Card className="flex w-full max-w-92 min-h-[600px] flex-col justify-between bg-linear-to-b from-primary/6 to-background">
+    <Card
+      className={cn(
+        "flex w-full max-w-92 min-h-[600px] flex-col justify-between bg-linear-to-b from-primary/6 to-background",
+        className
+      )}
+    >
       <CardHeader className="border-b">
-        <CardTitle className="text-lg sm:text-xl font-bold tracking-tight">
-          {creature.name}
-        </CardTitle>
-        <CardDescription className="text-sm text-foreground/75">
-          {creature.description}
-        </CardDescription>
-        <CardAction>
+        {hideIdentity ? null : (
+          <>
+            <CardTitle className="text-lg sm:text-xl font-bold tracking-tight">
+              {creature.name}
+            </CardTitle>
+            <CardDescription className="text-sm text-foreground/75">
+              {creature.description}
+            </CardDescription>
+          </>
+        )}
+        <CardAction
+          className={hideIdentity ? "col-start-1 row-start-1" : undefined}
+        >
           <Badge variant="secondary" className="whitespace-nowrap">
             Top {topPercentage}%
           </Badge>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The `/[username]` creature card was sharing a `max-w-96` flex row with the desktop stats panel. Revealing stats squeezed that row, shifted the card off-center, and repeated the creature name and full description beside the card.

## Changes
- Keep the creature card in a centered `max-w-96` column (`1fr / 24rem / 1fr` on large screens) so it stays the focal point
- Reveal stats in the right column without translating or shrinking the card
- Hide the duplicated name/description on the side stats panel (the dialog still shows them)
- Clip horizontal overflow on the profile page

## Test plan
- Open a profile such as `/contrary7nit` on desktop: the card should be horizontally centered
- Click **Reveal stats**: the card should stay centered; the side panel should show rank, GitHub stats, and share/download only
- Check tablet/mobile: **View stats** still opens the dialog
- Confirm the landing showcase cards are unchanged

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68290c5c-2290-481a-96ea-8b42227ca96f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68290c5c-2290-481a-96ea-8b42227ca96f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved creature card layouts on larger screens, including a dedicated area for creature stats.
  * Updated stats panels with smoother expanding and collapsing transitions.
  * Added support for displaying stats without repeating the creature’s name and description.
  * Prevented unwanted horizontal page overflow on creature profile pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->