### PR TITLE
fix(ui): readable stats toggle and unclipped card hover

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -63,7 +63,7 @@ async function CreatureCardWrapper({ params }: { params: Params }) {
 
 export default function CreaturePage({ params }: { params: Params }) {
   return (
-    <main className="flex min-h-svh w-full flex-col items-center justify-center overflow-x-hidden px-5 pt-20 pb-8">
+    <main className="flex min-h-svh w-full flex-col items-center justify-center overflow-x-clip px-5 pt-20 pb-8">
       <Suspense fallback={<Skeleton className="h-96 w-72" />}>
         <CreatureCardWrapper params={params} />
       </Suspense>

--- a/components/creature-card.tsx
+++ b/components/creature-card.tsx
@@ -247,7 +247,7 @@ export default async function CreatureCard({
   const cardDomId = `creature-card-${usernameLower}`;
 
   return (
-    <div className="flex w-full min-w-0 justify-center dark">
+    <div className="flex w-full min-w-0 justify-center">
       <div
         className={cn(
           "relative flex max-w-full flex-col items-center",
@@ -269,110 +269,114 @@ export default async function CreatureCard({
               "peer-checked:**:data-[state=reveal]:hidden peer-checked:**:data-[state=hide]:inline peer-checked:**:data-[slot=arrow]:rotate-180"
           )}
         >
-          {stats && (
-            <div className="absolute -top-10 right-0 z-10 flex justify-end">
-              <div className="w-full lg:hidden">
-                <CreatureStatsDialog triggerText="View stats">
-                  <CreatureStats
-                    creature={creature}
-                    downloadTargetId={cardDomId}
-                  />
-                </CreatureStatsDialog>
-              </div>
-
-              <Button
-                variant="outline"
-                size="sm"
-                className="hidden lg:inline-flex"
-                nativeButton={false}
-                render={<label htmlFor={toggleId} />}
-              >
-                <span data-state="reveal">Reveal stats</span>
-                <span data-state="hide" className="hidden">
-                  Hide stats
-                </span>
-                <HugeiconsIcon
-                  icon={ArrowRight01Icon}
-                  className="transition-transform duration-300 motion-reduce:transition-none"
-                  data-icon="inline-end"
-                  data-slot="arrow"
-                />
-              </Button>
-            </div>
-          )}
-
-          <ThreeDCard
-            enableShadow={false}
-            hoverPadding={0}
-            innerId={cardDomId}
-            trackOnWindow
-            className="w-full min-w-0"
-          >
-            <Card
-              className={cn(
-                "relative w-full max-w-full rounded-xl p-0",
-                theme.cardClassName
-              )}
+          <div className="relative">
+            <ThreeDCard
+              enableShadow={false}
+              hoverPadding={16}
+              innerId={cardDomId}
+              trackOnWindow
+              className="w-full min-w-0 dark"
             >
-              <div className="absolute left-3 top-3 z-20">
-                <Link
-                  href={githubProfileUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                  className={cn(
-                    "group relative inline-flex rounded-full p-px",
-                    emblemTheme.ringClassName,
-                    emblemTheme.glowClassName
-                  )}
-                >
-                  <span
-                    className={cn(
-                      "pointer-events-none absolute -inset-1 rounded-full blur opacity-35 transition-opacity group-hover:opacity-60",
-                      emblemTheme.ringClassName
-                    )}
-                  />
-                  <span className="relative inline-flex items-center gap-2 rounded-full border border-white/10 bg-background/70 px-3 py-1 text-xs font-semibold backdrop-blur supports-backdrop-filter:bg-background/50">
-                    <span
-                      className={cn("font-mono", emblemTheme.textClassName)}
-                    >
-                      @{usernameLower}
-                    </span>
-                  </span>
-                </Link>
-              </div>
-              <div
+              <Card
                 className={cn(
-                  "w-full absolute top-0 left-0 h-full border-3 rounded-[calc(var(--radius)+7px)]",
-                  theme.frameClassName
+                  "relative w-full max-w-full rounded-xl p-0",
+                  theme.cardClassName
                 )}
               >
-                {theme.effects}
-              </div>
-              <CardHeader className="p-0 flex flex-col gap-3">
-                <Image
-                  src={creature.image}
-                  alt={creature.name || "GitHub creature"}
-                  width={350}
-                  height={350}
-                  crossOrigin="anonymous"
-                  className="w-full"
-                />
-                <CardTitle
-                  data-export="title"
-                  className="px-4 text-2xl sm:text-2xl font-bold tracking-normal leading-tight"
+                <div className="absolute left-3 top-3 z-20">
+                  <Link
+                    href={githubProfileUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                    className={cn(
+                      "group relative inline-flex rounded-full p-px",
+                      emblemTheme.ringClassName,
+                      emblemTheme.glowClassName
+                    )}
+                  >
+                    <span
+                      className={cn(
+                        "pointer-events-none absolute -inset-1 rounded-full blur opacity-35 transition-opacity group-hover:opacity-60",
+                        emblemTheme.ringClassName
+                      )}
+                    />
+                    <span className="relative inline-flex items-center gap-2 rounded-full border border-white/10 bg-background/70 px-3 py-1 text-xs font-semibold backdrop-blur supports-backdrop-filter:bg-background/50">
+                      <span
+                        className={cn("font-mono", emblemTheme.textClassName)}
+                      >
+                        @{usernameLower}
+                      </span>
+                    </span>
+                  </Link>
+                </div>
+                <div
+                  className={cn(
+                    "absolute inset-0 overflow-hidden rounded-[calc(var(--radius)+7px)] border-3",
+                    theme.frameClassName
+                  )}
                 >
-                  <span className="bg-linear-to-r from-foreground via-foreground/90 to-foreground/70 bg-clip-text text-transparent">
-                    {creature.name}
+                  <div className="absolute inset-x-0 top-0 aspect-square overflow-hidden">
+                    {theme.effects}
+                  </div>
+                </div>
+                <CardHeader className="p-0 flex flex-col gap-3">
+                  <Image
+                    src={creature.image}
+                    alt={creature.name || "GitHub creature"}
+                    width={350}
+                    height={350}
+                    crossOrigin="anonymous"
+                    className="w-full"
+                  />
+                  <CardTitle
+                    data-export="title"
+                    className="px-4 text-2xl sm:text-2xl font-bold tracking-normal leading-tight"
+                  >
+                    <span className="bg-linear-to-r from-foreground via-foreground/90 to-foreground/70 bg-clip-text text-transparent">
+                      {creature.name}
+                    </span>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="px-4 pb-4">
+                  <p className="leading-relaxed text-balance text-foreground/80">
+                    {creature.description}
+                  </p>
+                </CardContent>
+              </Card>
+            </ThreeDCard>
+
+            {stats ? (
+              <div className="absolute top-7 right-7 z-30">
+                <div className="lg:hidden">
+                  <CreatureStatsDialog triggerText="View stats">
+                    <CreatureStats
+                      creature={creature}
+                      downloadTargetId={cardDomId}
+                    />
+                  </CreatureStatsDialog>
+                </div>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="hidden bg-background text-foreground shadow-sm lg:inline-flex"
+                  nativeButton={false}
+                  render={<label htmlFor={toggleId} />}
+                >
+                  <span data-state="reveal">Reveal stats</span>
+                  <span data-state="hide" className="hidden">
+                    Hide stats
                   </span>
-                </CardTitle>
-              </CardHeader>
-              <CardContent className="px-4 pb-4">
-                <p className="leading-relaxed text-balance text-foreground/80">
-                  {creature.description}
-                </p>
-              </CardContent>
-            </Card>
-          </ThreeDCard>
+                  <HugeiconsIcon
+                    icon={ArrowRight01Icon}
+                    className="transition-transform duration-300 motion-reduce:transition-none"
+                    data-icon="inline-end"
+                    data-slot="arrow"
+                  />
+                </Button>
+              </div>
+            ) : null}
+          </div>
         </div>
 
         {stats ? (

--- a/components/creature-stats-dialog.tsx
+++ b/components/creature-stats-dialog.tsx
@@ -25,7 +25,11 @@ export default function CreatureStatsDialog({
     <Dialog>
       <DialogTrigger
         render={
-          <Button variant="outline" size="sm" className="gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2 bg-background text-foreground shadow-sm"
+          >
             <HugeiconsIcon data-icon="inline-start" icon={Analytics01Icon} />
             {triggerText}
           </Button>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The `/[username]` profile page still had leftover UI bugs after #10 and #12.

## What was wrong
- The outer creature-card wrapper used `dark`, so Reveal/Hide (and mobile View stats) inherited dark-theme muted text on the light page. The control was nearly invisible.
- The toggle was absolutely positioned `-top-10`, so it floated above the card instead of belonging to it.
- Hovering the card tucked/clipped it. `overflow-x-hidden` on `<main>` (from #10) forces the other overflow axis to clip, so the 3D tilt got cut off. `hoverPadding={0}` left no local room for the tilt.

## Changes
- Keep the #12 flex + shrink-0 card/rail layout (card stays centered; rail only mounts when revealed)
- Scope `dark` to the creature card (`ThreeDCard`) so the card stays dark and page chrome does not
- Pin Reveal/Hide (and mobile View stats) to the card face, top-right, matching the `@username` badge
- Clip power-level effects to the image square only — do not clip the transformed card
- Give the profile `ThreeDCard` `hoverPadding={16}` so the tilt has room
- Change `<main>` from `overflow-x-hidden` to `overflow-x-clip` so page-level horizontal overflow is still blocked without clipping the vertical hover lift
- Homepage/showcase cards and the mobile dialog pattern are unchanged

## Test plan
- Open `/contrary7nit` in light mode at 1280 and 1024
- Confirm Reveal/Hide is a normal readable outline button on the card’s top-right
- Hover the card: the full 3D tilt/lift must stay visible (nothing tucked under the header or page edge)
- Reveal stats: card stays centered and does not shrink; rail still opens
- Below `lg`, View stats still opens the dialog
- Homepage showcase cards still have the dark creature-card look

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ab20f86b-e031-4412-933b-25637f873d0e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab20f86b-e031-4412-933b-25637f873d0e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved creature card layouts and visual effects.
  * Refined theme colors and added a subtle shadow to the stats control.
  * Updated overflow handling to clip content without creating a horizontal scroll container.
  * Repositioned the stats toggle and dialog within the card frame for a cleaner presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->