### PR TITLE
Move Reveal stats off the creature card

### DIFF
--- a/components/creature-card.tsx
+++ b/components/creature-card.tsx
@@ -269,118 +269,116 @@ export default async function CreatureCard({
               "peer-checked:**:data-[state=reveal]:hidden peer-checked:**:data-[state=hide]:inline peer-checked:**:data-[slot=arrow]:rotate-180"
           )}
         >
-          <div className="relative">
-            <ThreeDCard
-              enableShadow={false}
-              hoverPadding={16}
-              innerId={cardDomId}
-              trackOnWindow
-              className="w-full min-w-0 dark"
-            >
-              <Card
-                className={cn(
-                  "relative w-full max-w-full rounded-xl p-0",
-                  theme.cardClassName
-                )}
+          {stats ? (
+            <div className="mb-2 flex justify-end px-4">
+              <div className="lg:hidden">
+                <CreatureStatsDialog triggerText="View stats">
+                  <CreatureStats
+                    creature={creature}
+                    downloadTargetId={cardDomId}
+                  />
+                </CreatureStatsDialog>
+              </div>
+
+              <Button
+                variant="outline"
+                size="sm"
+                className="hidden bg-background text-foreground shadow-sm lg:inline-flex"
+                nativeButton={false}
+                render={<label htmlFor={toggleId} />}
               >
-                <div className="absolute left-3 top-3 z-20">
-                  <Link
-                    href={githubProfileUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className={cn(
-                      "group relative inline-flex rounded-full p-px",
-                      emblemTheme.ringClassName,
-                      emblemTheme.glowClassName
-                    )}
-                  >
-                    <span
-                      className={cn(
-                        "pointer-events-none absolute -inset-1 rounded-full blur opacity-35 transition-opacity group-hover:opacity-60",
-                        emblemTheme.ringClassName
-                      )}
-                    />
-                    <span className="relative inline-flex items-center gap-2 rounded-full border border-white/10 bg-background/70 px-3 py-1 text-xs font-semibold backdrop-blur supports-backdrop-filter:bg-background/50">
-                      <span
-                        className={cn("font-mono", emblemTheme.textClassName)}
-                      >
-                        @{usernameLower}
-                      </span>
-                    </span>
-                  </Link>
-                </div>
-                <div
+                <span data-state="reveal">Reveal stats</span>
+                <span data-state="hide" className="hidden">
+                  Hide stats
+                </span>
+                <HugeiconsIcon
+                  icon={ArrowRight01Icon}
+                  className="transition-transform duration-300 motion-reduce:transition-none"
+                  data-icon="inline-end"
+                  data-slot="arrow"
+                />
+              </Button>
+            </div>
+          ) : null}
+
+          <ThreeDCard
+            enableShadow={false}
+            hoverPadding={16}
+            innerId={cardDomId}
+            trackOnWindow
+            className="w-full min-w-0 dark"
+          >
+            <Card
+              className={cn(
+                "relative w-full max-w-full rounded-xl p-0",
+                theme.cardClassName
+              )}
+            >
+              <div className="absolute left-3 top-3 z-20">
+                <Link
+                  href={githubProfileUrl}
+                  target="_blank"
+                  rel="noreferrer"
                   className={cn(
-                    "absolute inset-0 overflow-hidden rounded-[calc(var(--radius)+7px)] border-3",
-                    theme.frameClassName
+                    "group relative inline-flex rounded-full p-px",
+                    emblemTheme.ringClassName,
+                    emblemTheme.glowClassName
                   )}
                 >
-                  <div className="absolute inset-x-0 top-0 aspect-square overflow-hidden">
-                    {theme.effects}
-                  </div>
-                </div>
-                <CardHeader className="p-0 flex flex-col gap-3">
-                  <Image
-                    src={creature.image}
-                    alt={creature.name || "GitHub creature"}
-                    width={350}
-                    height={350}
-                    crossOrigin="anonymous"
-                    className="w-full"
+                  <span
+                    className={cn(
+                      "pointer-events-none absolute -inset-1 rounded-full blur opacity-35 transition-opacity group-hover:opacity-60",
+                      emblemTheme.ringClassName
+                    )}
                   />
-                  <CardTitle
-                    data-export="title"
-                    className="px-4 text-2xl sm:text-2xl font-bold tracking-normal leading-tight"
-                  >
-                    <span className="bg-linear-to-r from-foreground via-foreground/90 to-foreground/70 bg-clip-text text-transparent">
-                      {creature.name}
+                  <span className="relative inline-flex items-center gap-2 rounded-full border border-white/10 bg-background/70 px-3 py-1 text-xs font-semibold backdrop-blur supports-backdrop-filter:bg-background/50">
+                    <span
+                      className={cn("font-mono", emblemTheme.textClassName)}
+                    >
+                      @{usernameLower}
                     </span>
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="px-4 pb-4">
-                  <p className="leading-relaxed text-balance text-foreground/80">
-                    {creature.description}
-                  </p>
-                </CardContent>
-              </Card>
-            </ThreeDCard>
-
-            {stats ? (
-              <div className="absolute top-7 right-7 z-30">
-                <div className="lg:hidden">
-                  <CreatureStatsDialog triggerText="View stats">
-                    <CreatureStats
-                      creature={creature}
-                      downloadTargetId={cardDomId}
-                    />
-                  </CreatureStatsDialog>
-                </div>
-
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="hidden bg-background text-foreground shadow-sm lg:inline-flex"
-                  nativeButton={false}
-                  render={<label htmlFor={toggleId} />}
-                >
-                  <span data-state="reveal">Reveal stats</span>
-                  <span data-state="hide" className="hidden">
-                    Hide stats
                   </span>
-                  <HugeiconsIcon
-                    icon={ArrowRight01Icon}
-                    className="transition-transform duration-300 motion-reduce:transition-none"
-                    data-icon="inline-end"
-                    data-slot="arrow"
-                  />
-                </Button>
+                </Link>
               </div>
-            ) : null}
-          </div>
+              <div
+                className={cn(
+                  "absolute inset-0 overflow-hidden rounded-[calc(var(--radius)+7px)] border-3",
+                  theme.frameClassName
+                )}
+              >
+                <div className="absolute inset-x-0 top-0 aspect-square overflow-hidden">
+                  {theme.effects}
+                </div>
+              </div>
+              <CardHeader className="p-0 flex flex-col gap-3">
+                <Image
+                  src={creature.image}
+                  alt={creature.name || "GitHub creature"}
+                  width={350}
+                  height={350}
+                  crossOrigin="anonymous"
+                  className="w-full"
+                />
+                <CardTitle
+                  data-export="title"
+                  className="px-4 text-2xl sm:text-2xl font-bold tracking-normal leading-tight"
+                >
+                  <span className="bg-linear-to-r from-foreground via-foreground/90 to-foreground/70 bg-clip-text text-transparent">
+                    {creature.name}
+                  </span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-4 pb-4">
+                <p className="leading-relaxed text-balance text-foreground/80">
+                  {creature.description}
+                </p>
+              </CardContent>
+            </Card>
+          </ThreeDCard>
         </div>
 
         {stats ? (
-          <aside className="hidden w-96 max-w-full shrink-0 lg:peer-checked:block">
+          <aside className="hidden w-96 max-w-full shrink-0 lg:mt-9 lg:peer-checked:block">
             <div className="p-3">
               <CreatureStats
                 creature={creature}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The Reveal/Hide stats control (and mobile View stats) was pinned to the card face after #11. It now sits **above** the card, still in the 24rem profile column, so it is no longer over the art, inside ThreeDCard/Card, or on the purple frame.

## Changes
- Place Reveal/Hide and View stats in document flow above the card, right-aligned to the card column, with a small gap so it does not overlap the hover tilt
- Keep `dark` scoped to the creature card only so the toggle stays readable on the light page
- Offset the revealed stats rail to stay aligned with the card (not the toggle)
- Homepage/showcase cards are unchanged (`stats` is off there)

## Checks
- Card stays centered at all breakpoints
- Toggle does not shrink the card
- Hidden rail still takes no flow space
- Side rail still uses `hideIdentity` (no duplicated name/description)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddb71e72-6f7b-4b12-a126-83b32791c32c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddb71e72-6f7b-4b12-a126-83b32791c32c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the creature card layout by moving the stats controls above the card.
  * Updated the desktop and mobile stats controls for clearer visibility and interaction.
  * Preserved the existing card content and stats panel behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->